### PR TITLE
Add URL of archived Fedora image

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,7 +13,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.provider :virtualbox do |vb|
       vb.memory = 8192
-      vb.cpus = 3
+      vb.cpus = 2
       vb.name = "v3spa_builder24"
   end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,6 +4,7 @@
 VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "fedora/24-cloud-base"
+  config.vm.box_url = "http://archives.fedoraproject.org/pub/archive/fedora/linux/releases/24/CloudImages/x86_64/images/Fedora-Cloud-Base-Vagrant-24-1.2.x86_64.vagrant-virtualbox.box"
 
   config.ssh.username = 'vagrant'
   config.ssh.password = 'vagrant'
@@ -12,7 +13,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.provider :virtualbox do |vb|
       vb.memory = 8192
-      vb.cpus = 2
+      vb.cpus = 3
       vb.name = "v3spa_builder24"
   end
 


### PR DESCRIPTION
The Fedora Core v24 image has been moved to the Fedora archives. Thus the URL has to be added in order to allow Vagrant to find the box file, otherwise Vagrant file will not build. 
Apart from that still working great btw, Thanks for this awesome tool!