### PR TITLE
Add checkbox to show only nodes with visible connections

### DIFF
--- a/src/js/controllers/explore.litcoffee
+++ b/src/js/controllers/explore.litcoffee
@@ -203,6 +203,10 @@
         $scope.nodeFilter.undo('node-hub')
         $scope.nodeFilter.nodesBy(nodeHub, 'node-hub').apply()
 
+      showConnectionsOnlyChangedCallback = () ->
+        $scope.applyFilters()
+        $scope.sigma.refresh()
+
       # User checked/unchecked something in the access vector filter
       avChangeCallback = () ->
         checkboxReducer = (map, currItem) ->
@@ -336,9 +340,18 @@
         addToAlwaysVisibleList: addToAlwaysVisibleList
         removeFromAlwaysVisibleList: removeFromAlwaysVisibleList
         clearAlwaysVisibleList: clearAlwaysVisibleList
+        showConnectionsOnlyChanged: showConnectionsOnlyChangedCallback
 
       $scope.applyFilters = () ->
         $scope.nodeFilter.apply()
+
+        # Filter for nodes with no visible connections after all other filters
+        # are applied.
+        if $scope.controls.connectionsOnly
+          g = $scope.sigma.graph
+          g.nodes().forEach((n) ->
+            n.hidden = n.hidden || _.every(g.adjacentEdges(n.id), (e) -> e.hidden)
+          )
 
       $scope.nodeFilter = new sigma.plugins.filter($scope.sigma)
 
@@ -364,6 +377,7 @@
           primary: true
           both: true
           comparison: true
+        connectionsOnly: false
 
       $scope.list_refpolicies = 
         query: (query)->

--- a/src/partials/explore.html
+++ b/src/partials/explore.html
@@ -29,6 +29,9 @@
           Filter by hub statistic
           <range-slider width="500" height="40" range="filters.hubRange" range-change-end="filters.hubChange(extent)"></range-slider>
         </div>
+        <div>
+            <label><input type="checkbox" ng-model="controls.connectionsOnly" ng-change="filters.showConnectionsOnlyChanged()" />Only show objects with visible connections</label>
+        </div>
       </div>
       <div class="row node-controls" ng-show="controls.tab == 'accessVectorTab'">
         <div class="col-xs-3"><av-filter title="Subjects" items="filters.subjList" selection-change="filters.avChange()"></av-filter></div>


### PR DESCRIPTION
This change adds a checkbox that allows the user to focus on a particular
network within the policy