### PR TITLE
Better errors when importing an sepolicy

### DIFF
--- a/api/handlers/ws_domains/refpolicy.py
+++ b/api/handlers/ws_domains/refpolicy.py
@@ -243,7 +243,7 @@ class RefPolicy(restful.ResourceDomain):
                     supported_docs['raw'] = True
 
                 if not supported_docs['dsl'] and not supported_docs['raw']:
-                    raise api.DisplayError("Cannot find binary policy or reference policy source in the zip file")
+                    raise api.DisplayError("Cannot find binary policy or reference policy source in the zip file: " + '\n'.join(errors))
 
                 if supported_docs['dsl'] is True:
                     # Import the policy into Lobster


### PR DESCRIPTION
It can be difficult to understand why a policy is not able to be parsed. This
makes it easier to identify when `setools` does not run correctly.